### PR TITLE
Grammar Generator/Parser: Assign parent nodes

### DIFF
--- a/grammars/f1_c_gen.py
+++ b/grammars/f1_c_gen.py
@@ -368,6 +368,7 @@ class CFuzzer(PyRecCompiledFuzzer):
                     'subnode = node_create_with_val(NODE_TERM__, "%s", %d);' % (
                         esc_token, len(esc_token_chars)))
             res.append('node->subnodes[%d] = subnode;' % i)
+            res.append('subnode->parent = node;')
         return '\n    '.join(res)
 
     def gen_num_candidate_rules(self, k):

--- a/lib/antlr4_shim/antlr4_shim.cpp
+++ b/lib/antlr4_shim/antlr4_shim.cpp
@@ -63,6 +63,7 @@ node_t *node_from_parse_tree(antlr4::tree::ParseTree *t) {
     auto &child = t->children[i];
     subnode = node_from_parse_tree(child);
     node->subnodes[i] = subnode;
+    subnode->parent = node;
   }
 
   return node;


### PR DESCRIPTION
These few cases were creating subnodes that did
not have parent nodes assigned. This caused the mutators
and trimming functions to create invalid trees because
they would assume that a node way down in the tree was
a valid "root node" and use it to replace a whole tree.