### PR TITLE
Make trimming work as intended

### DIFF
--- a/include/custom_mutator.h
+++ b/include/custom_mutator.h
@@ -42,10 +42,14 @@ typedef struct my_mutator {
   uint8_t cur_trimming_stage;  // 0: subtree trimming
                                // 1: recursive trimming
 
+  bool trim_was_effective; // Did we change the file *at all* during trim?
+
   size_t cur_subtree_trimming_step;
+  size_t finished_subtree_trimming_nodes;
   size_t total_subtree_trimming_steps;
 
   size_t cur_recursive_trimming_step;
+  size_t finished_recursive_trimming_edges;
   size_t total_recursive_trimming_steps;
 
   // Fuzzing

--- a/src/grammar_mutator.c
+++ b/src/grammar_mutator.c
@@ -295,7 +295,7 @@ int32_t afl_custom_post_trim(my_mutator_t *data, int success) {
     size_t new_node_size = data->tree_cur->non_terminal_node_list->size;
 
     // Set our progress equal to the remaining un-tested nodes in the list:
-    data->cur_subtree_trimming_step += data->total_subtree_trimming_steps - new_node_size;
+    data->cur_subtree_trimming_step = data->total_subtree_trimming_steps - new_node_size;
 
 
     // update the recursion edge list


### PR DESCRIPTION
* afl_custom_post_trim() was skipping too many
  things for subtree trimming and repeating too much work
  for recursion trimming. This patch makes those algorithms
  work as I believe they were intended to work.
* Avoid writing the tree file to disk until we are
  finished with the trimming stage.
* Write the trimmed tree into the chunk store when we are
  finished with the trimming stage.