### PR TITLE
grammar_mutator.c: Tame the random recursion

### DIFF
--- a/src/grammar_mutator.c
+++ b/src/grammar_mutator.c
@@ -328,7 +328,7 @@ uint32_t afl_custom_fuzz_count(my_mutator_t *                         data,
   data->total_random_mutation_steps = 100;
   if (data->tree_cur->recursion_edge_list->size > 0) {
 
-    data->total_random_recursive_mutation_steps = 20;
+    data->total_random_recursive_mutation_steps = 100;
 
   } else {
 
@@ -427,9 +427,26 @@ size_t afl_custom_fuzz(my_mutator_t *data, __attribute__((unused)) uint8_t *buf,
       tree = random_mutation(tree);
       break;
     case 2:
-      // random recursive mutation
-      tree = random_recursive_mutation(tree, random() % 10);
-      break;
+      {
+        // random recursive mutation
+        const unsigned RRM_GROWTH = 10; // Allow 2**RRM_GROWTH of bytes of expansion
+        tree_t *rrm_tree = NULL;
+        tree_to_buf(tree);
+        do {
+
+          if (rrm_tree) tree_free(rrm_tree);
+          rrm_tree = random_recursive_mutation(tree, random() % (RRM_GROWTH + 1));
+          tree_to_buf(rrm_tree);
+
+          // Make sure that the mutation doesn't grow more than RRM_GROWTH bytes per attempt!
+          // This is protecting against random_recursive_mutation's ability to
+          // create MASSIVE growth in a short period of time by duplicating big nodes.
+        } while (rrm_tree->data_len > (1 << RRM_GROWTH) + tree->data_len);
+
+        tree = rrm_tree;
+        break;
+
+      }
     case 3:
       // splicing mutation
       tree = splicing_mutation(tree);


### PR DESCRIPTION
This patch causes the random recursive mutation stage to only be
allowed to add up to 1k of extra bytes to the output file in a single
step. It might be a good idea to make this into an environment
variable or other tunable feature in the future.

The reason for this limitation is because the RRM stage can create
very MASSIVE growth of file size in a short period if it happens to
select a large subtree to duplicate. These huge files then become
a "sinkhole" for the fuzzer, where it spends most of its time
on further attempts to trim and/or mutate that file rather than
exploring other options.

With this limitation in place, strings and things that have relatively
short subtrees (and small character counts per recursion) can still
be expanded by fairly significant amounts, which is the main benefit
of this mutation stage.

Also, because the RRM is a bit more sane on each iteration, I increased
the number of allowed stages to make it still contribute to the overall
fuzzing process.