### PR TITLE
Generator fixes

### DIFF
--- a/grammars/f1_c_gen.py
+++ b/grammars/f1_c_gen.py
@@ -224,20 +224,50 @@ class PooledFuzzer(LimitFuzzer):
         return self.grammar_keys.index(k) + 1
 
     def get_trees_for_key(self, grammar, key='<start>'):
+        '''
+        For one key, generate a list of possible trees (one for each rule,
+        downsampled to self.MAX_SAMPLE).
+        '''
+        # If this is a terminal node, just put in the one node:
         if key not in grammar:
             return [TreeNode(node_type=0, val=key)]
-        v = sum([self.get_trees_for_rule(grammar, key, rule_id, rule)
-                 for rule_id, rule in enumerate(grammar[key])], [])
-        return random.sample(v, min(self.MAX_SAMPLE, len(v)))
+
+        # Enumerate the rules so we know how many there are and so we
+        # can match rule IDs correctly:
+        all_rules = list(enumerate(grammar[key]))
+
+        # Generate trees for up to MAX_SAMPLE of them.
+        # Each selected rule generates a list of trees (the subnodes of the rule), so this returns a list of lists.
+        downsampled_rules = random.sample(all_rules, min(self.MAX_SAMPLE, len(all_rules)))
+        return sum([self.get_trees_for_rule(grammar, key, rule_id, rule) for rule_id, rule in downsampled_rules],
+                   [])
 
     def get_trees_for_rule(self, grammar, key, rule_id, rule):
+        '''
+        For each subnode of a rule, generate a list of all possible trees.
+        '''
         assert grammar[key][rule_id] == rule
-        my_trees_list = [
-            self.get_trees_for_key(grammar, key) for key in rule]
-        v = [TreeNode(node_type=self.k_to_id(key), rule_id=rule_id,
-                      subnodes=subnodes)
-             for subnodes in itertools.product(*my_trees_list)]
-        return random.sample(v, min(self.MAX_SAMPLE, len(v)))
+        # Make a list of possible child trees for each subnode of this rule (each will be maximum of MAX_SAMPLE long)
+        # This is a list of lists, one list for each subnode.
+        subnode_possibilities = [self.get_trees_for_key(grammar, key) for key in rule]
+
+        # We want to randomly choose one option for each subnode to create a valid tree,
+        # and we want a maximum of MAX_SAMPLE total trees:
+        max_possible_trees = 1
+        for subnode in subnode_possibilities:
+            max_possible_trees *= len(subnode)
+
+        # Clamp the possibilities to something sane:
+        chosen_trees = min(max_possible_trees, self.MAX_SAMPLE)
+
+        def random_product(*args, repeat=1):
+            '''Pick ONE option from the equivalent of itertools.product()'''
+            pools = [tuple(pool) for pool in args] * repeat
+            return tuple(map(random.choice, pools))
+
+        # Select chosen_trees number of random valid sets of subnodes, and return a tree for each
+        return [TreeNode(node_type=self.k_to_id(key), rule_id=rule_id, subnodes=subnodes)
+                for subnodes in (random_product(*subnode_possibilities) for _ in range(chosen_trees))]
 
     def completion_trees(self):
         return {k: self.get_trees_for_key(self.c_grammar, k)

--- a/grammars/f1_c_gen.py
+++ b/grammars/f1_c_gen.py
@@ -421,14 +421,14 @@ class CFuzzer(PyRecCompiledFuzzer):
                 res.append('if (max_len < %d) {' % min_rule_size)
             else:
                 res.append('} else if (max_len < %d) {' % min_rule_size)
-            res.append('  num_rules = %d;' % num_candidate_rules)
+            res.append('  rules_that_fit = %d;' % num_candidate_rules)
 
         num_candidate_rules += num_min_rules[-1]
         if len(num_min_rules) == 1:
-            res.append('num_rules = %d;' % num_candidate_rules)
+            res.append('rules_that_fit = %d;' % num_candidate_rules)
         else:
             res.append('} else {')
-            res.append('  num_rules = %d;' % num_candidate_rules)
+            res.append('  rules_that_fit = %d;' % num_candidate_rules)
             res.append('}')
         return '\n    '.join(res)
 
@@ -453,15 +453,10 @@ node_t *gen_node_%(name)s(int max_len, int *consumed, int rule_index) {
   }
 
   if (rule_index < 0 || rule_index >= %(nrules)d) {
-    int num_rules = 0;
+    int rules_that_fit = 0;
     %(gen_num_candidate_rules)s
 
-    val = 0;
-    if (num_rules == %(num_min_rules)d) {
-      val = map_rand(%(num_min_rules)d);
-    } else {
-      val = map_rand(num_rules - %(num_min_rules)d) + %(num_min_rules)d;
-    }
+    val = map_rand(rules_that_fit);
   } else {
     val = rule_index;
   }
@@ -480,7 +475,6 @@ node_t *gen_node_%(name)s(int max_len, int *consumed, int rule_index) {
             'nrules': len(rules),
             'num_cheap_trees': len(cheap_trees),
             'min_cost': min_cost,
-            'num_min_rules': num_min_rules,
             'gen_num_candidate_rules': self.gen_num_candidate_rules(k)
         })
 


### PR DESCRIPTION
This changes the generator to use character count as the "cost" function in the generator,
with the goal of producing seeds that are strictly smaller than the allowed size.
It also generally creates shorter and simpler initial inputs, which is desirable for fuzzing even though
it might not be wanted for "general purpose seed generation".

The generator was previously choosing children rules
using some very weird map_rand() calls that appeared to
pretty much always just pick the last rule unless it was
approaching the character limit.

It tended to always pick deeply recursive rules in that case,
resulting in very large strings/numbers/whitespace/etc.

This change causes the rule mapping to work how I *think* it was
intended to work: It picks the rule randomly from the set of
rules that are capable of fitting into the available remaining
characters. This results in behavior like the "Naive generation"
policy from the original Nautilus paper.

The end result is that the random generation rules now favor
much shorter "recursions" in initial seeds. This means that
the mutator will keep the files relatively short (and
therefore fast!) for a while until the recursive mutator extends
these types of values.

## Important note:
This change causes the ParseTreeFromBuffer test to fail at
https://github.com/AFLplusplus/Grammar-Mutator/blob/stable/tests/test_tree.cpp#L244
when using JSON grammar. I'm not sure why, but the generator and ANTLR no longer fully agree on the tree structure although the end result is equal after calling tree_to_buf() on both of them. The ruby grammar does not show the same problem for some reason?