### PR TITLE
fix: revert '+' syntax optimize && add growth check limit for 'random_recursive_mutation'

### DIFF
--- a/grammars/f1_g4_translate.py
+++ b/grammars/f1_g4_translate.py
@@ -75,29 +75,10 @@ class AntlrG(Sanitize):
         t = t.replace('\t', '\\t')
         return t
 
-    def rule_to_s(self, key, rule, grammar):
-        # feat: add 'directly head/tail recursion' optimized syntax '+'
-        if len(rule) == 0:
-            return ''
-
-        # head recursion
-        recursion = False
-        if rule[0] == key:
-            rule = rule[1:]
-            recursion = True
-        # tail recursion
-        if rule[-1] == key:
-            rule = rule[:-1]
-            recursion = True
-
-        # append rules
-        data = ' '.join(["'%s'" % self.esc_token(t)
+    def rule_to_s(self, rule, grammar):
+        return ' '.join(["'%s'" % self.esc_token(t)
                          if t not in grammar else self.to_key(t)
                          for t in rule])
-
-        if recursion:
-            data = "(%s)+" % data
-        return data
 
     def translate(self):
         lines = ['grammar Grammar;']
@@ -108,7 +89,7 @@ entry
     ;''' % entries)
         for k in self.grammar_keys:
             rules = self.grammar[k]
-            v = '\n    | '.join([self.rule_to_s(k, rule, self.grammar)
+            v = '\n    | '.join([self.rule_to_s(rule, self.grammar)
                                  for rule in rules])
             lines.append('''\
 %s

--- a/src/grammar_mutator.c
+++ b/src/grammar_mutator.c
@@ -556,7 +556,11 @@ size_t afl_custom_fuzz(my_mutator_t *data, __attribute__((unused)) uint8_t *buf,
         const unsigned RRM_GROWTH = 10; // Allow 2**RRM_GROWTH of bytes of expansion
         tree_t *rrm_tree = NULL;
         tree_to_buf(tree);
+        int failed_count = 8;
         do {
+          if (failed_count-- <= 0) {
+            break;
+          }
 
           if (rrm_tree) tree_free(rrm_tree);
           rrm_tree =


### PR DESCRIPTION
for issue https://github.com/AFLplusplus/Grammar-Mutator/issues/42, I revert '+' syntax optimize

for issue https://github.com/AFLplusplus/Grammar-Mutator/issues/43, Grammar-Mutator has to rely on AST to work, in the case of TOKEN conflicts, grammar parsing may fail. at the same time, Grammar-Mutator will try to retain data for nodes that fail to parse. If the depth of the syntax tree is large and grammar parsing errors occur, it may cause `random_recursive_mutation` to be mutated each time. the data size exceeds 1024 bytes, thus falling into `do-while`. I added an failed limit for this.